### PR TITLE
add: wrapper function for htmlspecialchars

### DIFF
--- a/apps/common/utility.php
+++ b/apps/common/utility.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * htmlspecialcharsのラッパー関数
+ */
+function h(string $str): string {
+    return htmlspecialchars($str, ENT_QUOTES);
+}
+


### PR DESCRIPTION
htmlspecialcharsの使用頻度が高いわりに関数名が長いため